### PR TITLE
fix: ER-146: Run sfx is now continuous when changing decay states

### DIFF
--- a/src/player/player/audio_manager/audio_manager.gd
+++ b/src/player/player/audio_manager/audio_manager.gd
@@ -34,6 +34,7 @@ enum States {
 onready var player_audio = $PlayerAudio
 onready var aux_audio = $AuxAudio
 onready var powerup_audio = $PowerupAudio
+onready var sfx_players = [player_audio, aux_audio, powerup_audio]
 
 onready var audio_player = player_audio
 
@@ -95,19 +96,27 @@ func play_audio(state, sfx_player=0):
 func transition_walking_sfx(speed):
 	match speed:
 		0:
-			transition_to(States.MOVE_SLOW)
+			transition_to(States.MOVE_SLOW, 0)
 		1:
-			transition_to(States.MOVE_MEDIUM)
+			transition_to(States.MOVE_MEDIUM, 0)
 		2:
-			transition_to(States.MOVE_FAST)
+			transition_to(States.MOVE_FAST, 0)
 
 
-func stop_audio():
-	audio_player.stop()
-	audio_player.stream = null
+func stop_audio(sfx_player):
+	var _audio_player
+	match sfx_player:
+		0:
+			_audio_player = player_audio
+		1:
+			_audio_player = aux_audio
+		2:
+			_audio_player = powerup_audio
+	_audio_player.stop()
+	_audio_player.stream = null
 
 
-func transition_to(state, sfx_player=0):
-	stop_audio()
+func transition_to(state, sfx_player):
+	stop_audio(sfx_player)
 	play_audio(state, sfx_player)
 	emit_signal("transitioned", state)

--- a/src/player/state_machine/durability_states/_durability.gd
+++ b/src/player/state_machine/durability_states/_durability.gd
@@ -1,5 +1,7 @@
 extends State
 
+signal decay_state_changed
+
 #
 var move_speed_modifier = null
 var climb_speed_modifier = null
@@ -62,15 +64,14 @@ func _reduce_durability():
 		_:
 			push_error("Invalid durability state!")
 	
-	audio_manager.transition_to(audio_manager.States.DECAY)
-	# If the player is running we want to swap the sounds out
-	if _actor.state_machine.state.get_index() == 1:
-		audio_manager.transition_walking_sfx(new_state_index)
+	audio_manager.transition_to(audio_manager.States.DECAY, 1)
 	
 	if is_timer_active:
 		reset_timer()
 	
 	_state_machine.transition_to(new_state_name)
+	
+	emit_signal("decay_state_changed")
 
 
 func _increase_durability():
@@ -98,11 +99,14 @@ func _increase_durability():
 		reset_timer()
 	
 	_state_machine.transition_to(new_state_name)
+	
+	emit_signal("decay_state_changed")
 
 
 func reset_timer():
 	decay_timer.wait_time = max_wait_time
 	decay_timer.start()
+
 
 func _start_decay_timer():
 	# Reset the durability timer
@@ -127,12 +131,6 @@ func set_is_timer_active(value):
 
 func set_state_colour(value: Color):
 	state_colour = value
-#	var material = _actor.debug_mesh.get_surface_material(0)
-#	material.set_albedo(state_colour)
-#	_actor.debug_mesh.set_surface_material(0, material)
 	
 	# Set the ui colour
 	_actor.durability_ui.color = state_colour
-	
-
-	

--- a/src/player/state_machine/states/_movement.gd
+++ b/src/player/state_machine/states/_movement.gd
@@ -62,31 +62,32 @@ func physics_process(delta: float):
 		if Input.is_action_just_pressed("p1_repair"):
 			if GlobalFlags.DEBUG_POWERUPS:
 				_actor.durability_state_machine.get_child(0)._increase_durability()
-				audio_manager.transition_to(audio_manager.States.USE_ADD)
+				audio_manager.transition_to(audio_manager.States.USE_ADD, 1)
 			else:
 				if _actor.pickup_count > 0:
 					if _actor.durability_state_machine.state.get_index() > 0:
 						_actor.pickup_count -= 1
 						_actor.durability_state_machine.get_child(0)._increase_durability()
 						#
-						audio_manager.transition_to(audio_manager.States.USE_ADD)
+						audio_manager.transition_to(audio_manager.States.USE_ADD, 1)
 					else:
 						# Play invalid repair sound here
-						audio_manager.transition_to(audio_manager.States.EMPTY)
+						audio_manager.transition_to(audio_manager.States.EMPTY, 1)
+
 		elif Input.is_action_just_pressed("p1_unrepair"):
 			if GlobalFlags.DEBUG_POWERUPS:
 				_actor.durability_state_machine.get_child(0)._reduce_durability()
-				audio_manager.transition_to(audio_manager.States.USE_REMOVE)
+				audio_manager.transition_to(audio_manager.States.USE_REMOVE, 1)
 			else:
 				if _actor.reverse_pickup_count > 0:
 					if _actor.durability_state_machine.state.get_index() < 2:
 						_actor.reverse_pickup_count -= 1
 						_actor.durability_state_machine.get_child(0)._reduce_durability()
 						#
-						audio_manager.transition_to(audio_manager.States.USE_REMOVE)
+						audio_manager.transition_to(audio_manager.States.USE_REMOVE, 1)
 					else:
 						# Play invalid repair sound here
-						audio_manager.transition_to(audio_manager.States.EMPTY)
+						audio_manager.transition_to(audio_manager.States.EMPTY, 1)
 	
 	# Movement
 	if GlobalFlags.PLAYER_CONTROLS_ACTIVE:

--- a/src/player/state_machine/states/air_dashing.gd
+++ b/src/player/state_machine/states/air_dashing.gd
@@ -12,7 +12,7 @@ var dash_velocity
 
 func enter(msg: Dictionary = {}):
 	_parent.using_root_motion = false
-	audio_manager.transition_to(audio_manager.States.AIR_DASH)
+	audio_manager.transition_to(audio_manager.States.AIR_DASH, 1)
 	
 	# MESH
 	var skin = _actor.skin

--- a/src/player/state_machine/states/air_dashing_aiming.gd
+++ b/src/player/state_machine/states/air_dashing_aiming.gd
@@ -8,8 +8,7 @@ var dash_vector
 
 func enter(_msg: Dictionary = {}):
 	_parent.using_root_motion = false
-	audio_manager.transition_to(audio_manager.States.AIR_DASH_AIM)
-	#	audio_player.transition_to(audio_player.States.JUMP)
+	audio_manager.transition_to(audio_manager.States.AIR_DASH_AIM, 0)
 	
 	# MESH
 	var skin = _actor.skin

--- a/src/player/state_machine/states/climbing.gd
+++ b/src/player/state_machine/states/climbing.gd
@@ -25,7 +25,7 @@ func enter(_msg: Dictionary = {}):
 	climb()
 
 	#
-	audio_manager.transition_to(audio_manager.States.CLIMB)
+	audio_manager.transition_to(audio_manager.States.CLIMB, 1)
 
 
 func physics_process(_delta):

--- a/src/player/state_machine/states/dead.gd
+++ b/src/player/state_machine/states/dead.gd
@@ -19,7 +19,7 @@ func enter(msg: Dictionary = {}):
 	_parent.input_direction = Vector3.ZERO
 #	_parent.move_direction = Vector3.ZERO
 	#
-	audio_manager.transition_to(audio_manager.States.DIE)
+	audio_manager.transition_to(audio_manager.States.DIE, 1)
 	
 	# MESH
 	var skin = _actor.skin

--- a/src/player/state_machine/states/double_jumping.gd
+++ b/src/player/state_machine/states/double_jumping.gd
@@ -19,7 +19,7 @@ func enter(_msg: Dictionary = {}):
 	var skin = _actor.skin
 	skin.transition_to(skin.States.DOUBLE_JUMP)
 	#
-	audio_manager.transition_to(audio_manager.States.DOUBLE_JUMP)
+	audio_manager.transition_to(audio_manager.States.DOUBLE_JUMP, 0)
 	
 	_actor.climbing_rays.transform.origin = _actor.climb_ray_pos_double_jump
 

--- a/src/player/state_machine/states/falling.gd
+++ b/src/player/state_machine/states/falling.gd
@@ -17,7 +17,7 @@ func enter(msg: Dictionary = {}):
 	_parent.move_speed = move_speed
 	_parent.jump_impulse = jump_impulse
 	#
-	audio_manager.transition_to(audio_manager.States.IDLE)
+	audio_manager.transition_to(audio_manager.States.IDLE, 0)
 	
 	# MESH
 	var skin = _actor.skin
@@ -42,11 +42,11 @@ func physics_process(delta: float):
 	if _actor.is_on_floor():
 		if _parent.input_direction == Vector3.ZERO:
 			# Idle
-			audio_manager.transition_to(audio_manager.States.LAND, 1)
+#			audio_manager.transition_to(audio_manager.States.LAND, 1)
 			_state_machine.transition_to("Movement/Idle")
 		else:
 			# Walking
-			audio_manager.transition_to(audio_manager.States.LAND, 1)
+#			audio_manager.transition_to(audio_manager.States.LAND, 1)
 			_state_machine.transition_to("Movement/Running")
 	else:
 		if Input.is_action_pressed("p1_jump"):
@@ -70,7 +70,6 @@ func physics_process(delta: float):
 
 
 func exit():
-#	audio_player.transition_to(audio_player.States.LAND)
 	_parent.exit()
 
 

--- a/src/player/state_machine/states/idle.gd
+++ b/src/player/state_machine/states/idle.gd
@@ -15,7 +15,7 @@ func enter(_msg: Dictionary = {}):
 	var skin = _actor.skin
 	skin.transition_to(skin.States.IDLE)
 	
-	audio_manager.transition_to(audio_manager.States.IDLE)
+	audio_manager.transition_to(audio_manager.States.IDLE, 0)
 	
 	_actor.climbing_rays.transform.origin = _actor.climb_ray_pos_normal
 

--- a/src/player/state_machine/states/jumping.gd
+++ b/src/player/state_machine/states/jumping.gd
@@ -21,7 +21,7 @@ func enter(_msg: Dictionary = {}):
 	var skin = _actor.skin
 	skin.transition_to(skin.States.JUMP)
 	#
-	audio_manager.transition_to(audio_manager.States.JUMP)
+	audio_manager.transition_to(audio_manager.States.JUMP, 0)
 	
 	_actor.climbing_rays.transform.origin = _actor.climb_ray_pos_jump
 

--- a/src/player/state_machine/states/running.gd
+++ b/src/player/state_machine/states/running.gd
@@ -21,8 +21,20 @@ func enter(_msg: Dictionary = {}):
 	
 	# AUDIO
 	
-	var walk_sfx = get_walk_sfx()
-	audio_manager.transition_to(walk_sfx)
+	# We want to call the update sfx function every time we change decay state
+	# to make sure we're playing the right audio track for the current move speed
+	if not _actor.durability_parent.is_connected(
+		"decay_state_changed",
+		self,
+		"_update_sfx"
+	):
+		_actor.durability_parent.connect(
+			"decay_state_changed",
+			self,
+			"_update_sfx"
+		)
+	
+	_update_sfx()
 	
 	# MESH
 	var skin = _actor.skin
@@ -31,21 +43,8 @@ func enter(_msg: Dictionary = {}):
 	_actor.climbing_rays.transform.origin = _actor.climb_ray_pos_normal
 
 
-func get_walk_sfx():
-	var walk_sfx_state
-	# FIXME - this really needs to be an actor level variable
-	match _actor.durability_parent._state_machine.state.get_index():
-		# Solid - slowest
-		0:
-			walk_sfx_state = audio_manager.States.MOVE_SLOW
-		# Damaged - medium
-		1:
-			walk_sfx_state = audio_manager.States.MOVE_MEDIUM
-		# Eroded - fastest
-		2:
-			walk_sfx_state = audio_manager.States.MOVE_FAST
-	
-	return walk_sfx_state
+func get_walk_sfx_index():
+	return _actor.durability_parent._state_machine.state.get_index()
 
 
 func unhandled_input(event: InputEvent):
@@ -92,3 +91,12 @@ func physics_process(delta: float):
 
 func exit():
 	_parent.exit()
+
+
+func _update_sfx():
+	# Only run if we are currently in the running state
+	if _state_machine.state != self:
+		return
+	var walk_sfx = get_walk_sfx_index()
+	audio_manager.transition_walking_sfx(walk_sfx)
+


### PR DESCRIPTION
This was due to the decay/repair powerup sfx calls not having an explicit `sfx_player` arg, causing them to default to 0 - indicating the player_sfx AudioStreamPlayer node. This caused the powerup sfx to prevent the running sfx from playing.

Setting the `transition_to` calls to require an explicit sfx_player by removing the default arg value should prevent this issue from recurring.